### PR TITLE
Add validation input

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,14 @@ module.exports = (input, options) => {
 		...options
 	};
 
+	if (typeof input !== 'string' && typeof input !== 'number') {
+		throw new TypeError(`Expected an String/Number in the second argument, got ${typeof input}`);
+	}
+
+	if (isNaN(input)) {
+		throw new TypeError(`Expected an valid number, or a valid numerical string, got '${input}'`);
+	}
+
 	if (input < 1e3) {
 		return input;
 	}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "short-numbers",
-	"version": "0.0.0",
+	"version": "0.1.0",
 	"description": "Make short numbers from long numbers",
 	"license": "MIT",
 	"repository": "abranhe/short-numbers",

--- a/test.js
+++ b/test.js
@@ -1,8 +1,15 @@
 import test from 'ava';
 import shortNumbers from '.';
 
-// eslint-disable-next-line no-warning-comments
-// TODO Expected a number or a parsable number only
+test('Invalid input', t => {
+	const error = t.throws(() => shortNumbers({}), TypeError);
+	t.is(error.message, 'Expected an String/Number in the second argument, got object');
+});
+
+test('Non numerical string', t => {
+	const error = t.throws(() => shortNumbers('abc'), TypeError);
+	t.is(error.message, 'Expected an valid number, or a valid numerical string, got \'abc\'');
+});
 
 test('Negative numbers', t => {
 	t.is(shortNumbers(-1), -1);
@@ -37,6 +44,6 @@ test('Options', t => {
 	t.is(shortNumbers('1000', {k: 'k'}), '1k');
 	t.is(shortNumbers('10300', {space: true}), '10.3 K');
 	t.is(shortNumbers('1000000', {m: 'million', space: true}), '1 million');
-	t.is(shortNumbers('1000000000', {b: 'Billion', space: true}), '1 Billion');
-	t.is(shortNumbers('1000000000000', {t: 'Trillion', space: true}), '1 Trillion');
+	t.is(shortNumbers('1000000000', {b: 'billion', space: true}), '1 billion');
+	t.is(shortNumbers('1000000000000', {t: 'trillion', space: true}), '1 trillion');
 });


### PR DESCRIPTION
###### Before

```js
shortNumbers('37a');
// Nothing happend
```
###### After

```js
shortNumbers('37a');
// TypeError 'Expected an valid number, or a valid numerical string, got 37a'
```